### PR TITLE
Fix media path

### DIFF
--- a/beamerthemeuiucposter.sty
+++ b/beamerthemeuiucposter.sty
@@ -90,7 +90,7 @@
       \end{column}
       \begin{column}{.3\paperwidth}%
         \vspace*{3ex}
-        \includegraphics[width=\textwidth]{illinois-wordmark-light-letters.pdf}%
+        \includegraphics[width=\textwidth]{media/illinois-wordmark-light-letters.pdf}%
       \end{column}
       \begin{column}{.045\paperwidth}%
       \end{column}


### PR DESCRIPTION
When I use this template with Overleaf, I get the error message as follows,
```
Package pdftex.def Error: File `illinois-wordmark-light-letters.pdf' not found: using draft setting.
```
Fixed by changing the figure path.

Although the compilation script can resolve it via `TEXINPUTS`, using a relative path for this fixed logo might be more convenient—especially when working with an online editor.